### PR TITLE
fix(website): update privacy policy last updated date

### DIFF
--- a/website/pages/privacy-policy/privacy-policy.json
+++ b/website/pages/privacy-policy/privacy-policy.json
@@ -1,7 +1,7 @@
 {
     "title": "Privacy Policy",
     "lastUpdated": {
-      "date": "January 31, 2025",
+      "date": "June 11, 2026",
       "icon": "https://raw.githubusercontent.com/melmua/static-assets/main/website/pages/privacy-policy/icons/calendar.svg",
       "icon_alt": "M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
     },


### PR DESCRIPTION
## Summary
- Update the "Last updated" date on the Privacy Policy from January 31, 2025 to June 11, 2026 to reflect recent content updates, matching the Terms & Conditions page.

## Test plan
- [x] Validated `privacy-policy.json` with `python3 -m json.tool`